### PR TITLE
Fix stack URL to the new format

### DIFF
--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -6,7 +6,7 @@ success_color = "17bd81"
 warning_color = "f2a40b"
 
 # START run state changes.
-stack_url = sprintf("https://%s.spacelift.io/stack/%s", [
+stack_url = sprintf("https://%s.app.spacelift.io/stack/%s", [
     input.account.name,
     input.run_updated.stack.id,
 ])
@@ -129,7 +129,7 @@ as_html_list(resources) = sprintf("<ul>%s</ul>", [
 
 
 # START module version state changes.
-module_url := sprintf("https://%s.spacelift.io/module/%s", [
+module_url := sprintf("https://%s.app.spacelift.io/module/%s", [
     input.account.name,
     input.module_version.module.id,
 ])


### PR DESCRIPTION
It seems like the module is 99.9% working, but the slack/module URL in the resulting Teams message is malformed.

Previous Stack/Module base URL (after formatting/sprintf):
```
https://example.spacelift.io/stack/{id}
```

However, this URL returns 404 (did the DNS/CNAME change from the early days? Do we need backwards compatibility?) and clicking the stack's link from the resulting message does not work as intended.

If this was actually intended and done so to keep it backwards compatible, maybe we can add a variable to the module and further build on the policy to handle the edge case.

Proposed Stack/Module base URL (after formatting/sprintf):
```
https://example.app.spacelift.io/stack/{id}
```