### PR TITLE
feat: ensure unique policy name (#6)

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.1.0
+module_version: 0.2.0
 
 tests:
   - name: Default test

--- a/policy.tf
+++ b/policy.tf
@@ -1,5 +1,7 @@
+resource "random_uuid" "this" {}
+
 resource "spacelift_policy" "msteams-integration" {
-  name     = "MS Teams Integration (${var.channel_name})"
+  name     = "MS Teams Integration (${var.channel_name}) <${random_uuid.this.result}>"
   type     = "NOTIFICATION"
   space_id = var.space_id
 

--- a/providers.tf
+++ b/providers.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "spacelift-io/spacelift"
       version = ">= 1.1.4"
     }
+    random = {
+      source = "hashicorp/random"
+      version = ">= 3.6.1"
+    }
   }
 }


### PR DESCRIPTION
This change introduces a fix for #6.

To ensure uniqueness for policy names created by this module, we can use the `random_uuid` resource from the `hashicorp/random` provider.

**Policy name before this change**
```MS Teams Integration (My Channel Name)```

**Policy name after this change**
```MS Teams Integration (My Channel Name) <8E15AAE8-8534-4C12-9FAE-41419DC44CA2>```