### PR TITLE
feat: support selfhosted spacelift urls (#5)

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -4,3 +4,14 @@ module_version: 0.1.1
 tests:
   - name: Default test
     project_root: ".spacelift/test"
+  - name: Test with a valid custom spacelift_url
+    project_root: ".spacelift/test"
+    environment:
+      TF_VAR_spacelift_url: "https://devnull-as-a-service.com"
+  - name: Test with an invalid custom spacelift_url
+    project_root: ".spacelift/test"
+    negative: true
+    environment:
+      TF_VAR_spacelift_url: "devnull-as-a-service.com/"
+
+

--- a/.spacelift/test/test.tf
+++ b/.spacelift/test/test.tf
@@ -11,10 +11,16 @@ provider "spacelift" {}
 
 variable "spacelift_run_id" {}
 
+variable "spacelift_url" {
+  type    = string
+  default = "app.spacelift.io"
+}
+
 module "msteams-integration" {
   source = "../../"
 
   channel_name = var.spacelift_run_id
   space_id     = "public-modules-01GVNH2CJKSKHRSMDPBMQ3WZT9"
   webhook_url  = "https://devnull-as-a-service.com/dev/null"
+  spacelift_url = var.spacelift_url
 }

--- a/.spacelift/test/test.tf
+++ b/.spacelift/test/test.tf
@@ -10,6 +10,7 @@ terraform {
 provider "spacelift" {}
 
 variable "spacelift_run_id" {}
+variable "spacelift_space_id" {}
 
 variable "spacelift_url" {
   type    = string
@@ -20,7 +21,7 @@ module "msteams-integration" {
   source = "../../"
 
   channel_name = var.spacelift_run_id
-  space_id     = "public-modules-01GVNH2CJKSKHRSMDPBMQ3WZT9"
+  space_id     = var.spacelift_space_id
   webhook_url  = "https://devnull-as-a-service.com/dev/null"
   spacelift_url = var.spacelift_url
 }

--- a/assets/policy-custom.rego
+++ b/assets/policy-custom.rego
@@ -1,0 +1,215 @@
+package spacelift
+
+# Common settings.
+fail_color = "e21717"
+success_color = "17bd81"
+warning_color = "f2a40b"
+
+# START run state changes.
+stack_url = sprintf("${spacelift_url}/stack/%s", [
+    input.run_updated.stack.id,
+])
+
+run_url = sprintf("%s/run/%s", [
+    stack_url,
+    input.run_updated.run.id,
+])
+
+interesting_run_states = {
+    "DISCARDED": { "color": fail_color, "title": "has been discarded" },
+    "FAILED": { "color": fail_color, "title": "has failed" },
+    "FINISHED": { "color": success_color, "title": "has finished" },
+    "STOPPED": { "color": fail_color, "title": "has been stopped" },
+    "UNCONFIRMED": { "color": warning_color, "title": "is pending confirmation" },
+}
+
+interesting_run_types = {
+    "TRACKED": "Tracked run",
+    "TASK": "Custom task",
+}
+
+run_state := input.run_updated.run.state
+run_type := input.run_updated.run.type
+
+# Run state changes.
+webhook[{"endpoint_id": endpoint_id, "payload": run_payload}] {
+	# Send the webhook to any endpoint labeled as "msteams".
+	endpoint := input.webhook_endpoints[_]
+	endpoint.labels[_] == "msteams"
+	endpoint_id := endpoint.id
+
+	# Only send the webhook if both the run state and type are interesting.
+	interesting_run_states[run_state]
+    interesting_run_types[run_type]
+}
+
+# Best reference for the payload schema.
+# https://adaptivecards.io/samples/
+run_payload = {
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": interesting_run_states[run_state].color,
+    "summary": sprintf("%s %s", [
+        interesting_run_types[run_type],
+        interesting_run_states[run_state].title],
+    ),
+    "sections": run_sections,
+}
+
+# Main section.
+run_sections[{
+    "activityTitle": sprintf("[%s](%s) %s", [
+        interesting_run_types[run_type],
+        run_url,
+        interesting_run_states[run_state].title,
+    ]),
+    "activitySubtitle": sprintf("Stack [%s](%s)", [
+        input.run_updated.stack.name,
+        stack_url,
+    ]),
+    "facts": run_facts,
+    "markdown": true
+}]
+
+run_sections[{
+    "activityTitle": sprintf("%s resources (%d)", [
+        resource_section,
+        count(collection),
+    ]),
+    "text": as_html_list(collection)
+}] {
+    run_type == "TRACKED"
+    resource_section := {"Added","Changed","Deleted","Replaced"}[_]
+    collection := resources(lower(resource_section))
+    count(collection) > 0
+}
+
+run_facts[{ "name": "Command", "value": value }] {
+    run_type == "TASK"
+    value := sprintf("`%s`", [input.run_updated.run.command])
+}
+
+run_facts[{ "name": "Branch", "value": value }] {
+    run_type != "TASK"
+    value :=  input.run_updated.run.commit.branch
+}
+
+run_facts[{ "name": "Commit", "value": value }] {
+    run_type != "TASK"
+    value := sprintf("[%s](%s) by %s", [
+        input.run_updated.run.commit.message,
+        input.run_updated.run.commit.hash,
+        input.run_updated.run.commit.author,
+    ])
+}
+
+run_facts[{ "name": "Triggered by", "value": value }] {
+    value := input.run_updated.run.triggered_by
+}
+
+run_facts[{ "name": "Created at", "value": value }] {
+    value := time.format(input.run_updated.run.created_at)
+}
+
+run_facts[{ "name": "Space", "value": value }] {
+    value := input.run_updated.stack.space.name
+}
+
+resources(type) = [change.entity.address |
+    change := input.run_updated.run.changes[_]
+    change.phase == "plan"
+    contains(change.action, type)
+]
+
+as_html_list(resources) = sprintf("<ul>%s</ul>", [
+    concat("", [sprintf("<li>%s</li>", [resource]) | resource := resources[_]]),
+])
+# END run state changes.
+
+
+# START module version state changes.
+module_url := sprintf("${spacelift_url}/module/%s", [
+    input.module_version.module.id,
+])
+
+version_number := input.module_version.version.number
+version_state := input.module_version.version.state
+version_url := sprintf("%s/version/%s", [
+    module_url,
+    input.module_version.version.id,
+])
+
+interesting_version_states = {
+    "ACTIVE": { "color": success_color, "title": "has been published" },
+    "FAILED": { "color": fail_color, "title": "has failed" },
+}
+
+# Module version state changes.
+webhook[{"endpoint_id": endpoint_id, "payload": version_payload}] {
+	# Send the webhook to any endpoint labeled as "msteams".
+	endpoint := input.webhook_endpoints[_]
+	endpoint.labels[_] == "msteams"
+	endpoint_id := endpoint.id
+
+	# Only send the webhook if the version state is interesting.
+	interesting_version_states[version_state]
+}
+
+version_payload = {
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": interesting_version_states[version_state].color,
+    "summary": sprintf("Module version %s %s", [
+        version_number,
+        interesting_version_states[version_state].title,
+    ]),
+    "sections": version_sections,
+}
+
+version_sections[{
+    "activityTitle": sprintf("[Module version %s](%s) %s", [
+        version_number,
+        version_url,
+        interesting_version_states[version_state].title,
+    ]),
+    "activitySubtitle": sprintf("Module [%s](%s)", [
+        input.module_version.module.name,
+        module_url,
+    ]),
+    "facts": version_facts,
+    "markdown": true
+}]
+
+version_facts[{ "name": "Branch", "value": value }] {
+    value :=  input.module_version.version.commit.branch
+}
+
+version_facts[{ "name": "Commit", "value": value }] {
+    value := sprintf("[%s](%s) by %s", [
+        input.module_version.version.commit.message,
+        input.module_version.version.commit.hash,
+        input.module_version.version.commit.author,
+    ])
+}
+
+version_facts[{ "name": "Created at", "value": value }] {
+    value := time.format(input.module_version.version.created_at)
+}
+
+version_facts[{ "name": "Space", "value": value }] {
+    value := input.module_version.module.space.name
+}
+
+version_facts[{ "name": name, "value": value }] {
+    some i
+    run := input.module_version.version.test_runs[i]
+
+    name := sprintf("Test case #%02d: %q", [i + 1, run.title])
+    value := sprintf("[%s](%s)", [
+        run.state,
+        sprintf("%s/run/%s", [version_url, run.id]),
+    ])
+}
+
+# Sample if we actually send a webhook.
+sample { count(webhook) > 0 }

--- a/policy.tf
+++ b/policy.tf
@@ -3,6 +3,13 @@ resource "spacelift_policy" "msteams-integration" {
   type     = "NOTIFICATION"
   space_id = var.space_id
 
-  body   = file("${path.module}/assets/policy.rego")
+  body   = local.is_custom_spacelift_url ? local.custom_policy : local.default_policy
   labels = ["msteams"]
+}
+
+locals {
+  default_policy = file("${path.module}/assets/policy.rego")
+  custom_policy  = templatefile("${path.module}/assets/policy-custom.rego", {
+    spacelift_url = var.spacelift_url
+  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,23 @@ variable "webhook_url" {
   description = "URL of the MS Teams channel incoming webhook connector to send notifications to."
   sensitive   = true
 }
+
+variable "spacelift_url" {
+  type        = string
+  description = "URL of the Spacelift instance to use. (default: app.spacelift.io)"
+  default     = "app.spacelift.io"
+  // If the value is not app.spacelift.io, then we expect https or http to be provided
+  validation {
+    condition     = var.spacelift_url == "app.spacelift.io" || can(regex("^(https|http)://", var.spacelift_url))
+    error_message = "spacelift_url must be either app.spacelift.io or a valid URL starting with http:// or https://"
+  }
+  // Value must not contain a trailing slash
+  validation {
+    condition     = !can(regex(".*/$", var.spacelift_url))
+    error_message = "spacelift_url must not contain a trailing slash"
+  }
+}
+
+locals {
+  is_custom_spacelift_url = var.spacelift_url != "app.spacelift.io"
+}


### PR DESCRIPTION
This change addresses #5.

With this change we introduce the `spacelift_url`  variable. The default value is `app.spacelift.io`. When using the default value, no changes should be noticed from previous versions.

When `spacelift_url` is set to the non-default value, a new policy file will be applied (`assets/policy-custom.rego`):
- The `templatefile` function will replace `${spacelift_url}` in the OPA file with the value of `var.spacelift_url`
- URLs in this custom OPA file use the following formats
  - ${spacelift_url}/module/
  - ${spacelift_url}/stack/

**Testing**
Two new tests have been introduced
1. Test setting spacelift_url to a non-default value
2. Negative test for an invalid custom spacelift_url

**Other Changes**
1. The hard-coded `space_id` in tests was changed to var.spacelift_space_id. This allows non-spacelifters to test.