### PR TITLE
Rework notification for Workflows integration

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.1.1
+module_version: 0.2.0
 
 tests:
   - name: Default test

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ module "spacelift_msteams" {
 
 Based on this configuration, the module will send notifications to the `My channel` channel in Microsoft Teams that look like these:
 
-![Run notification](https://docs.spacelift.io/assets/screenshots/msteams-run-state.png)
+![Run pending confirmation notification](https://docs.spacelift.io/assets/screenshots/msteams-run-pending.png)
 
-![Version notification](https://docs.spacelift.io/assets/screenshots/msteams-module-version.png)
+![Run finished notification](https://docs.spacelift.io/assets/screenshots/msteams-run-finished.png)
+
+![Module version notification](https://docs.spacelift.io/assets/screenshots/msteams-module-version.png)
 
 ## Prerequisites
 

--- a/assets/policy.rego
+++ b/assets/policy.rego
@@ -1,35 +1,31 @@
 package spacelift
 
-# Common settings.
-fail_color = "e21717"
-success_color = "17bd81"
-warning_color = "f2a40b"
-
 # START run state changes.
 stack_url = sprintf("https://%s.app.spacelift.io/stack/%s", [
-    input.account.name,
-    input.run_updated.stack.id,
+	input.account.name,
+	input.run_updated.stack.id,
 ])
 
 run_url = sprintf("%s/run/%s", [
-    stack_url,
-    input.run_updated.run.id,
+	stack_url,
+	input.run_updated.run.id,
 ])
 
 interesting_run_states = {
-    "DISCARDED": { "color": fail_color, "title": "has been discarded" },
-    "FAILED": { "color": fail_color, "title": "has failed" },
-    "FINISHED": { "color": success_color, "title": "has finished" },
-    "STOPPED": { "color": fail_color, "title": "has been stopped" },
-    "UNCONFIRMED": { "color": warning_color, "title": "is pending confirmation" },
+	"DISCARDED": {"style": "attention", "title": "has been discarded"},
+	"FAILED": {"style": "attention", "title": "has failed"},
+	"FINISHED": {"style": "good", "title": "has finished"},
+	"STOPPED": {"style": "attention", "title": "has been stopped"},
+	"UNCONFIRMED": {"style": "warning", "title": "is pending confirmation"},
 }
 
 interesting_run_types = {
-    "TRACKED": "Tracked run",
-    "TASK": "Custom task",
+	"TRACKED": "Tracked run",
+	"TASK": "Custom task",
 }
 
 run_state := input.run_updated.run.state
+
 run_type := input.run_updated.run.type
 
 # Run state changes.
@@ -41,109 +37,136 @@ webhook[{"endpoint_id": endpoint_id, "payload": run_payload}] {
 
 	# Only send the webhook if both the run state and type are interesting.
 	interesting_run_states[run_state]
-    interesting_run_types[run_type]
-}
-
-# Best reference for the payload schema.
-# https://adaptivecards.io/samples/
-run_payload = {
-    "@type": "MessageCard",
-    "@context": "http://schema.org/extensions",
-    "themeColor": interesting_run_states[run_state].color,
-    "summary": sprintf("%s %s", [
-        interesting_run_types[run_type],
-        interesting_run_states[run_state].title],
-    ),
-    "sections": run_sections,
+	interesting_run_types[run_type]
 }
 
 # Main section.
-run_sections[{
-    "activityTitle": sprintf("[%s](%s) %s", [
-        interesting_run_types[run_type],
-        run_url,
-        interesting_run_states[run_state].title,
-    ]),
-    "activitySubtitle": sprintf("Stack [%s](%s)", [
-        input.run_updated.stack.name,
-        stack_url,
-    ]),
-    "facts": run_facts,
-    "markdown": true
-}]
+run_payload = {
+	"type": "message",
+	"attachments": [{
+		"contentType": "application/vnd.microsoft.card.adaptive",
+		"contentUrl": null,
+		"content": {
+			"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+			"type": "AdaptiveCard",
+			"version": "1.5",
+			"body": [
+				{
+					"type": "Container",
+					"items": [{
+						"type": "TextBlock",
+						"text": sprintf("[%s](%s) %s", [
+							interesting_run_types[run_type],
+							run_url,
+							interesting_run_states[run_state].title,
+						]),
+						"size": "large",
+						"weight": "bolder",
+					}],
+					"style": interesting_run_states[run_state].style,
+				},
+				{
+					"type": "FactSet",
+					"facts": run_facts,
+				},
+				{
+					"type": "Container",
+					"items": run_resources,
+				},
+			],
+		},
+	}],
+}
 
-run_sections[{
-    "activityTitle": sprintf("%s resources (%d)", [
-        resource_section,
-        count(collection),
-    ]),
-    "text": as_html_list(collection)
+run_resources[{
+	"type": "Container",
+	"items": [
+		{
+			"type": "TextBlock",
+			"text": sprintf("%s resources (%d)", [
+				resource_section,
+				count(collection),
+			]),
+			"weight": "bolder",
+		},
+		{
+			"type": "TextBlock",
+			"text": as_list(collection),
+		},
+	],
 }] {
-    run_type == "TRACKED"
-    resource_section := {"Added","Changed","Deleted","Replaced"}[_]
-    collection := resources(lower(resource_section))
-    count(collection) > 0
+	run_type == "TRACKED"
+	resource_section := {"Added", "Changed", "Deleted", "Replaced"}[_]
+	collection := resources(lower(resource_section))
+	count(collection) > 0
 }
 
-run_facts[{ "name": "Command", "value": value }] {
-    run_type == "TASK"
-    value := sprintf("`%s`", [input.run_updated.run.command])
+run_facts[{"title": "Stack", "value": value}] {
+	value := sprintf("[%s](%s)", [
+		input.run_updated.stack.name,
+		stack_url,
+	])
 }
 
-run_facts[{ "name": "Branch", "value": value }] {
-    run_type != "TASK"
-    value :=  input.run_updated.run.commit.branch
+run_facts[{"title": "Command", "value": value}] {
+	run_type == "TASK"
+	value := sprintf("`%s`", [input.run_updated.run.command])
 }
 
-run_facts[{ "name": "Commit", "value": value }] {
-    run_type != "TASK"
-    value := sprintf("[%s](%s) by %s", [
-        input.run_updated.run.commit.message,
-        input.run_updated.run.commit.hash,
-        input.run_updated.run.commit.author,
-    ])
+run_facts[{"title": "Branch", "value": value}] {
+	run_type != "TASK"
+	value := input.run_updated.run.commit.branch
 }
 
-run_facts[{ "name": "Triggered by", "value": value }] {
-    value := input.run_updated.run.triggered_by
+run_facts[{"title": "Commit", "value": value}] {
+	run_type != "TASK"
+	value := sprintf("[%s](%s) by %s", [
+		input.run_updated.run.commit.message,
+		input.run_updated.run.commit.url,
+		input.run_updated.run.commit.author,
+	])
 }
 
-run_facts[{ "name": "Created at", "value": value }] {
-    value := time.format(input.run_updated.run.created_at)
+run_facts[{"title": "Triggered by", "value": value}] {
+	value := input.run_updated.run.triggered_by
 }
 
-run_facts[{ "name": "Space", "value": value }] {
-    value := input.run_updated.stack.space.name
+run_facts[{"title": "Created at", "value": value}] {
+	value := time.format(input.run_updated.run.created_at)
+}
+
+run_facts[{"title": "Space", "value": value}] {
+	value := input.run_updated.stack.space.name
 }
 
 resources(type) = [change.entity.address |
-    change := input.run_updated.run.changes[_]
-    change.phase == "plan"
-    contains(change.action, type)
+	change := input.run_updated.run.changes[_]
+	change.phase == "plan"
+	contains(change.action, type)
 ]
 
-as_html_list(resources) = sprintf("<ul>%s</ul>", [
-    concat("", [sprintf("<li>%s</li>", [resource]) | resource := resources[_]]),
-])
-# END run state changes.
+as_list(resources) = concat("\r", [sprintf("- %s", [resource]) | resource := resources[_]])
 
+# END run state changes.
 
 # START module version state changes.
 module_url := sprintf("https://%s.app.spacelift.io/module/%s", [
-    input.account.name,
-    input.module_version.module.id,
+	input.account.name,
+	input.module_version.module.id,
 ])
 
 version_number := input.module_version.version.number
+
 version_state := input.module_version.version.state
+
 version_url := sprintf("%s/version/%s", [
-    module_url,
-    input.module_version.version.id,
+	module_url,
+	input.module_version.version.id,
 ])
 
 interesting_version_states = {
-    "ACTIVE": { "color": success_color, "title": "has been published" },
-    "FAILED": { "color": fail_color, "title": "has failed" },
+	"ACTIVE": {"style": "good", "title": "has been published"},
+	"FAILED": {"style": "attention", "title": "has failed"},
 }
 
 # Module version state changes.
@@ -158,60 +181,118 @@ webhook[{"endpoint_id": endpoint_id, "payload": version_payload}] {
 }
 
 version_payload = {
-    "@type": "MessageCard",
-    "@context": "http://schema.org/extensions",
-    "themeColor": interesting_version_states[version_state].color,
-    "summary": sprintf("Module version %s %s", [
-        version_number,
-        interesting_version_states[version_state].title,
-    ]),
-    "sections": version_sections,
+	"type": "message",
+	"attachments": [{
+		"contentType": "application/vnd.microsoft.card.adaptive",
+		"contentUrl": null,
+		"content": {
+			"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+			"type": "AdaptiveCard",
+			"version": "1.5",
+			"body": [
+				{
+					"type": "Container",
+					"items": [{
+						"type": "TextBlock",
+						"text": sprintf("[Module version %s](%s) %s", [
+							version_number,
+							version_url,
+							interesting_version_states[version_state].title,
+						]),
+						"size": "large",
+						"weight": "bolder",
+					}],
+					"style": interesting_version_states[version_state].style,
+				},
+				{
+					"type": "FactSet",
+					"facts": version_facts,
+				},
+				{
+					"type": "Table",
+					"firstRowAsHeader": false,
+					"showGridLines": false,
+					"columns": [
+						{"width": 1},
+						{"width": 2},
+						{"width": 1},
+					],
+					"rows": version_tests,
+				},
+			],
+		},
+	}],
 }
 
-version_sections[{
-    "activityTitle": sprintf("[Module version %s](%s) %s", [
-        version_number,
-        version_url,
-        interesting_version_states[version_state].title,
-    ]),
-    "activitySubtitle": sprintf("Module [%s](%s)", [
-        input.module_version.module.name,
-        module_url,
-    ]),
-    "facts": version_facts,
-    "markdown": true
-}]
-
-version_facts[{ "name": "Branch", "value": value }] {
-    value :=  input.module_version.version.commit.branch
+version_facts[{"title": "Module", "value": value}] {
+	value := sprintf("[%s](%s)", [
+		input.module_version.module.name,
+		module_url,
+	])
 }
 
-version_facts[{ "name": "Commit", "value": value }] {
-    value := sprintf("[%s](%s) by %s", [
-        input.module_version.version.commit.message,
-        input.module_version.version.commit.hash,
-        input.module_version.version.commit.author,
-    ])
+version_facts[{"title": "Branch", "value": value}] {
+	value := input.module_version.version.commit.branch
 }
 
-version_facts[{ "name": "Created at", "value": value }] {
-    value := time.format(input.module_version.version.created_at)
+version_facts[{"title": "Commit", "value": value}] {
+	value := sprintf("[%s](%s) by %s", [
+		input.module_version.version.commit.message,
+		input.module_version.version.commit.url,
+		input.module_version.version.commit.author,
+	])
 }
 
-version_facts[{ "name": "Space", "value": value }] {
-    value := input.module_version.module.space.name
+version_facts[{"title": "Created at", "value": value}] {
+	value := time.format(input.module_version.version.created_at)
 }
 
-version_facts[{ "name": name, "value": value }] {
-    some i
-    run := input.module_version.version.test_runs[i]
+version_facts[{"title": "Space", "value": value}] {
+	value := input.module_version.module.space.name
+}
 
-    name := sprintf("Test case #%02d: %q", [i + 1, run.title])
-    value := sprintf("[%s](%s)", [
-        run.state,
-        sprintf("%s/run/%s", [version_url, run.id]),
-    ])
+version_tests[{
+	"type": "TableRow",
+	"cells": [
+		{
+			"type": "TableCell",
+			"items": [{
+				"type": "TextBlock",
+				"text": name,
+				"weight": "bolder",
+				"wrap": true,
+			}],
+		},
+		{
+			"type": "TableCell",
+			"items": [{
+				"type": "TextBlock",
+				"text": title,
+				"weight": "bolder",
+				"wrap": true,
+			}],
+		},
+		{
+			"type": "TableCell",
+			"items": [{
+				"type": "TextBlock",
+				"text": value,
+			}],
+		},
+	],
+}] {
+	some i
+	run := input.module_version.version.test_runs[i]
+
+	name := sprintf("Test case #%02d", [i + 1])
+	title := sprintf("%q", [run.title])
+	value := sprintf("[%s](%s)", [
+		run.state,
+		sprintf("%s/run/%s", [version_url, run.id]),
+	])
 }
 
 # Sample if we actually send a webhook.
-sample { count(webhook) > 0 }
+sample {
+	count(webhook) > 0
+}


### PR DESCRIPTION
Let's make the notification compatible with Workflows.

https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/

## Tracked run is pending confirmation

### Before

![CleanShot 2024-12-23 at 15 12 20@2x](https://github.com/user-attachments/assets/ffb18cba-1560-42d8-8c2c-2b9e6ebf8309)

### After

![CleanShot 2024-12-23 at 15 12 49@2x](https://github.com/user-attachments/assets/16940a4c-b1d6-4d56-9a90-3132059af434)

## Tracked run has finished

### Before

![CleanShot 2024-12-23 at 15 13 20@2x](https://github.com/user-attachments/assets/7ed4ac76-1a56-459d-b2e2-5e39d21b6fa7)

### After

![CleanShot 2024-12-23 at 15 13 40@2x](https://github.com/user-attachments/assets/d58fa706-144d-45cf-bc10-b26275ae85df)

## Module version has been published

### Before

![CleanShot 2024-12-23 at 15 14 37@2x](https://github.com/user-attachments/assets/b10b5dea-7c1b-4314-906c-2629768654ad)

### After

![CleanShot 2024-12-23 at 15 15 05@2x](https://github.com/user-attachments/assets/8f2cf361-6794-417c-9ef2-07b91d2e96bc)